### PR TITLE
fix: open left side bar link in new tab

### DIFF
--- a/src/components/HighlightBlogSection.vue
+++ b/src/components/HighlightBlogSection.vue
@@ -82,6 +82,6 @@ const blogSectionList = [
 ];
 
 const clickLink = (link: string) => {
-  window.open(link, "_self");
+  window.open(link, "_blank");
 };
 </script>


### PR DESCRIPTION
Otherwise, the collections link can't reload the page to show the history chart