### PR TITLE
fix: embed code for dark mode

### DIFF
--- a/src/components/EmbedMarkdownSection.vue
+++ b/src/components/EmbedMarkdownSection.vue
@@ -55,17 +55,22 @@ const repoText = computed(() => {
     return "your repository's";
   }
 });
-const embedCode = computed(() => {
+
+function generateEmbedCode(repos: string, type: string) {
   return `## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=${store.repos.join(
-    ","
-  )}&type=${store.chartMode}#gh-light-mode-only)](${window.location.href})
-[![Star History Chart](https://api.star-history.com/svg?repos=${store.repos.join(
-    ","
-  )}&type=${store.chartMode}&theme=dark#gh-dark-mode-only)](${window.location.href})
-
+<a href="${window.location.href}">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=${repos}&type=${type}&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=${repos}&type=${type}" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=${repos}&type=${type}" />
+  </picture>
+</a>
 `;
+}
+
+const embedCode = computed(() => {
+  return generateEmbedCode(store.repos.join(","), store.chartMode);
 });
 
 const handleCopyBtnClick = () => {


### PR DESCRIPTION
`#gh-light-mode-only` will not adapt according to the Theme if the image is not hosted on the GitHub.

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to