### PR TITLE
docs: update chatgpt.js post w/ 100.builders news

### DIFF
--- a/public/blog/chatgpt-js.md
+++ b/public/blog/chatgpt-js.md
@@ -14,7 +14,7 @@ Back in 2022, OpenAI had been releasing large language models to the public sinc
 
 Even before that, OpenAI had been releasing versions of GPT privately for [nearly five years](https://cdn.openai.com/research-covers/language-unsupervised/language_understanding_paper.pdf).
 
-It was not until the launch of ChatGPT (powered by GPT-3.5) on November 20, 2022, did AI finally capture the mainstream imagination of humankind, becoming the [fastest-growing app in the history of the universe](https://www.zdnet.com/article/chatgpt-just-became-the-fastest-growing-app-of-all-time/) (outpacing even TikTok/Douyin) and never letting go.
+It was not until the launch of ChatGPT (powered by GPT-3.5) on November 20, 2022, did AI finally capture the mainstream imagination of humankind — becoming the *[fastest-growing app in the history of the universe](https://www.zdnet.com/article/chatgpt-just-became-the-fastest-growing-app-of-all-time/)* (outpacing even TikTok/Douyin!)
 
 Unsurprisingly, an ecosystem of tools that either utilize or enhance the AI's astounding power has blossomed.
 

--- a/public/blog/chatgpt-js.md
+++ b/public/blog/chatgpt-js.md
@@ -94,3 +94,5 @@ Two main events can be attributed with causing this astonishing growth spurt:
 **chatgpt.js** is continuously maintained, with new features added based on user demand in the [GitHub repo](https://github.com/kudoai/chatgpt.js).
 
 The project is open to sponsorships: if you are a company or individual and believe in the project, you can consider [pioneering chatgpt.js growth](https://github.com/sponsors/kudoai)!
+
+*8/14 Update — chatgpt.js is now part of [100 Builders](https://100.builders), an AI incubator funded by industry heavyweights like [Stability.ai](https://stability.ai) (creators of Stable Diffusion) & [Coinbase Ventures](https://ventures.coinbase.com)!*


### PR DESCRIPTION
A few weeks ago, organizers of 100 Builders (an open-source AI incubator) reached out to invite me to apply for chatgpt.js to be in the program. Today, they finally emailed to accept the project!

I think this makes for an awesome & inspiring update for other GitHub users (also they're still accepting late applications for another 4 days, so readers may find utility by applying) so I added it as a footnote (also slightly revised 3rd paragraph for improved readability)

