### PR TITLE
fix(extension): use URL constructor to get repo

### DIFF
--- a/src/extension/Popup.vue
+++ b/src/extension/Popup.vue
@@ -134,16 +134,14 @@ const token = computed(() => {
 
 onMounted(async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const url = tab.url + "/";
+  const url = new URL(tab.url);
 
-  try {
-    const result = /github.com\/(\S+?\/\S+?)\//.exec(url);
-    if (result) {
-      state.repo = result[1];
-      await fetchReposStarData([state.repo]);
+  if (url.hostname === 'github.com') {
+    const [owner, repo] = url.pathname.split('/').filter(Boolean);
+    if (owner && repo) {
+        state.repo = `${owner}/${repo}`;
+        await fetchReposStarData([state.repo]);
     }
-  } catch (err) {
-    // do nth
   }
 
   if (!state.repo) {


### PR DESCRIPTION
Closes #328. Works with query parameters, hashes, etc. It first uses the [`URL()` constructor](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) to parse the URL and return a [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) object. We can use the [`hostname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/hostname) property of the `URL` object to make sure we are on `github.com`, and then split the [`pathname`](https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname) property of the `URL` object by the `/` character and filter out falsy values. With this array of path elements from the split `pathname` we can take the first two, make sure they are both truthy, and then use a string template to put the `owner` and `repo` variables into the desired format (`${owner}/${repo}`).

You can see it working on this GitHub repository here:

![Screenshot of the Chrome Dev Console showing the code in the PR working successfully with query parameters and hashes](https://github.com/star-history/star-history/assets/47499684/639f3ebe-b6bc-49b0-b24a-6403ea24f48f)
![Screenshot of the Chrome Dev Console showing the code in the PR working successfully with a long URL path](https://github.com/star-history/star-history/assets/47499684/bb08f514-a01b-4f0f-b2a9-f8ce16820c28)

And working correctly (but not logging anything) on website that is **not** a GitHub repository:

![Screenshot of the code in the PR being executed but not returning anything on example.com](https://github.com/star-history/star-history/assets/47499684/3af4a183-b728-40c9-8d52-7938ec6aa695)
![Screenshot of the code in the PR being executed but not returning anything on github.com](https://github.com/star-history/star-history/assets/47499684/028381b1-f8c4-46d6-bbe7-6fc0996fdb8f)

