### PR TITLE
Fix #391

### DIFF
--- a/common/api.ts
+++ b/common/api.ts
@@ -66,7 +66,7 @@ namespace api {
         requestPages.push(Math.round((i * pageCount) / maxRequestAmount) - 1);
       });
       if (!requestPages.includes(1)) {
-        requestPages.unshift(1);
+        requestPages[0] = 1;
       }
     }
 


### PR DESCRIPTION
### Before my fix

```javascript
requestPages = {0, ...}
// 1 not in requestPages, unshift(1)
requestPages = {1, 0, ...}
```

### After my fix

```javascript
requestPages = {0, ...}
// 1 not in requestPages, requestPages[0] = 1
requestPages = {1, ...}
```