### PR TITLE
Enable client-side caching and only cache logo url, not the image itself

### DIFF
--- a/backend/main.ts
+++ b/backend/main.ts
@@ -12,7 +12,6 @@ import cache from "./cache.js";
 import {
   getChartWidthWithSize,
   replaceSVGContentFilterWithCamelcase,
-  getBase64Image,
 } from "./utils.js";
 import { getNextToken, initTokenFromEnv } from "./token.js";
 import { CHART_SIZES, CHART_TYPES, MAX_REQUEST_AMOUNT } from "./const.js";
@@ -70,11 +69,10 @@ const startServer = async () => {
         const data = await getRepoData(nodataRepos, token, MAX_REQUEST_AMOUNT);
 
         for (const d of data) {
-          const logoUrl = await getBase64Image(d.logoUrl);
           cache.set(d.repo, {
             starRecords: d.starRecords,
             starAmount: d.starRecords[d.starRecords.length - 1].count,
-            logoUrl,
+            logoUrl: d.logoUrl,
           });
           repoData.push(d);
         }
@@ -139,11 +137,8 @@ const startServer = async () => {
     };
     const optimized = optimize(svgContent, options).data;
 
-    const now = new Date();
     ctx.type = "image/svg+xml;charset=utf-8";
-    ctx.set("cache-control", "no-cache");
-    ctx.set("date", `${now}`);
-    ctx.set("expires", `${now}`);
+    ctx.set("cache-control", "max-age=86400");
     ctx.body = optimized;
   });
 


### PR DESCRIPTION
This PR enables client-side caching for 24 hours and also fixes the server-side caching data to not store the entire repo owner's logo. Before this, the server-side cache was likely only able to hold ~5000 repositories but this should now make it able to hold ~1.2M repos.

Fixes https://github.com/star-history/star-history/issues/473