### PR TITLE
Add back the avatar image to base64 conversion

### DIFF
--- a/backend/main.ts
+++ b/backend/main.ts
@@ -12,6 +12,7 @@ import cache from "./cache.js";
 import {
   getChartWidthWithSize,
   replaceSVGContentFilterWithCamelcase,
+  getBase64Image,
 } from "./utils.js";
 import { getNextToken, initTokenFromEnv } from "./token.js";
 import { CHART_SIZES, CHART_TYPES, MAX_REQUEST_AMOUNT } from "./const.js";
@@ -69,6 +70,7 @@ const startServer = async () => {
         const data = await getRepoData(nodataRepos, token, MAX_REQUEST_AMOUNT);
 
         for (const d of data) {
+          d.logoUrl = await getBase64Image(`${d.logoUrl}&size=22`);
           cache.set(d.repo, {
             starRecords: d.starRecords,
             starAmount: d.starRecords[d.starRecords.length - 1].count,


### PR DESCRIPTION
I made a mistake in https://github.com/star-history/star-history/pull/474 where since I was testing locally, the SVG rendered was able to directly reach out to the GitHub avatars endpoint but when deployed to production, the generated SVG gets cached and served behind the Github camo servers. This results in camo serving the SVG and not allowing remote image loading due to the content security policy and thus blocks the loading of the avatars image when embedded in GitHub projects.

So we will have to add back the avatar to base64 image downloader but there is one optimization that we can make. Since the avatar logo is rendered at a width and height of just 22 pixels, we only need to download the size 22 image. GitHub lets us do this by just passing a `size=<scale>` to the avatars endpoint!

This will result in a bit larger cache item but it's only ~2400 bytes compared to the cache size of the original item with the full, original, avatar image which was 299030 bytes. This means that you can have roughly 460k repositories in your 1GB cache.