### PR TITLE
fix: change footer text to Back to home

### DIFF
--- a/frontend/components/PageShell.tsx
+++ b/frontend/components/PageShell.tsx
@@ -8,7 +8,7 @@ export default function PageShell({ children }: { children: React.ReactNode }) {
                 <NavInput />
                 {children}
                 <div className="mt-6 text-sm text-neutral-400">
-                    <Link href="/" className="hover:text-neutral-600 transition-colors">star-history.com</Link>
+                    <Link href="/" className="hover:text-neutral-600 transition-colors">Back to home</Link>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Change "star-history.com" to "Back to home" in the repo detail page footer

## Test plan
- [ ] Verify Cloudflare Pages preview deployment triggers
- [ ] Check the preview URL shows the updated text on repo pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)