### PR TITLE
Add "Date from" filter to chart (closes #50)

### DIFF
--- a/backend/main.ts
+++ b/backend/main.ts
@@ -5,7 +5,7 @@ import { serve } from "@hono/node-server";
 import { optimize } from 'svgo';
 import { JSDOM } from "jsdom";
 import XYChart from "../shared/packages/xy-chart.js";
-import { convertDataToChartData, getRepoData } from "../shared/common/chart.js";
+import { convertDataToChartData, getRepoData, isValidIsoDateString } from "../shared/common/chart.js";
 import { ChartMode } from "../shared/types/chart.js";
 import logger from "./logger.js";
 import cache, { ogCardCache, svgCache, recordCacheHit, recordCacheMiss, getAllCacheStats } from "./cache.js";
@@ -152,10 +152,10 @@ const startServer = async () => {
 
     let startDate: string | null = null;
     if (fromParam) {
-      if (/^\d{4}-\d{2}-\d{2}$/.test(fromParam) && !isNaN(Date.parse(fromParam))) {
+      if (isValidIsoDateString(fromParam)) {
         startDate = fromParam;
       } else {
-        return c.text("Invalid 'from' parameter: expected YYYY-MM-DD", 400);
+        return c.text("Invalid 'from' parameter: expected a real calendar date in YYYY-MM-DD form", 400);
       }
     }
 

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -146,8 +146,18 @@ const startServer = async () => {
     const typeParam = c.req.query("type") ?? "";
     const logscaleParam = c.req.query("logscale");
     const legendParam = c.req.query("legend") ?? "";
+    const fromParam = c.req.query("from") ?? "";
     let type: ChartMode = "Date";
     let size = c.req.query("size") ?? "";
+
+    let startDate: string | null = null;
+    if (fromParam) {
+      if (/^\d{4}-\d{2}-\d{2}$/.test(fromParam) && !isNaN(Date.parse(fromParam))) {
+        startDate = fromParam;
+      } else {
+        return c.text("Invalid 'from' parameter: expected YYYY-MM-DD", 400);
+      }
+    }
 
     if (typeParam) {
       const lowerType = typeParam.toLowerCase();
@@ -174,7 +184,7 @@ const startServer = async () => {
     }
 
     // Check rendered SVG cache before any data fetching or rendering.
-    const svgCacheKey = `${repos.join(",")}|${type}|${size}|${theme}|${transparent}|${legendPosition}|${useLogScale}`;
+    const svgCacheKey = `${repos.join(",")}|${type}|${size}|${theme}|${transparent}|${legendPosition}|${useLogScale}|${startDate ?? ""}`;
     const cachedSvg = svgCache.get(svgCacheKey);
     if (cachedSvg) {
       recordCacheHit("svgChart");
@@ -254,7 +264,7 @@ const startServer = async () => {
           title: "Star History",
           xLabel: type === "Date" ? "Date" : "Timeline",
           yLabel: "GitHub Stars",
-          data: convertDataToChartData(repoData, type),
+          data: convertDataToChartData(repoData, type, { startDate }),
           showDots: false,
           transparent: transparent.toLowerCase() === "true",
           theme: theme === "dark" ? "dark" : "light",

--- a/frontend/components/RepoInputer.tsx
+++ b/frontend/components/RepoInputer.tsx
@@ -91,7 +91,7 @@ export default function RepoInputer({ setChartVisibility }: RepoInputerProps) {
                     hash += "&logscale"
                 }
                 hash += `&legend=${store.state.legendPosition}`
-                if (store.state.startDate) {
+                if (store.state.startDate && store.state.chartMode !== "Timeline") {
                     hash += `&from=${store.state.startDate}`
                 }
             }

--- a/frontend/components/RepoInputer.tsx
+++ b/frontend/components/RepoInputer.tsx
@@ -91,13 +91,16 @@ export default function RepoInputer({ setChartVisibility }: RepoInputerProps) {
                     hash += "&logscale"
                 }
                 hash += `&legend=${store.state.legendPosition}`
+                if (store.state.startDate) {
+                    hash += `&from=${store.state.startDate}`
+                }
             }
             // Sync location hash only right here
             window.location.hash = hash
         }
 
         handleWatch()
-    }, [store.state.repos, store.state.chartMode, store.state.useLogScale, store.state.legendPosition, state.repos])
+    }, [store.state.repos, store.state.chartMode, store.state.useLogScale, store.state.legendPosition, store.state.startDate, state.repos])
 
     const handleAddRepoBtnClick = () => {
         if (store.isFetching) {

--- a/frontend/components/StarChartViewer.tsx
+++ b/frontend/components/StarChartViewer.tsx
@@ -108,7 +108,7 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
             } else {
                 setState((prevState) => ({
                     ...prevState,
-                    chartData: convertDataToChartData(repoData, chartMode ?? state.chartMode, { insertZeroPoint: true })
+                    chartData: convertDataToChartData(repoData, chartMode ?? state.chartMode, { insertZeroPoint: true, startDate: store.state.startDate })
                 }))
             }
         },
@@ -160,6 +160,25 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [store.repos])
+
+    // Re-compute chart from cache when startDate changes (no network request needed)
+    useEffect(() => {
+        if (store.repos.length === 0) return
+        const repoData: RepoData[] = []
+        for (const repo of store.repos) {
+            const cached = state.repoCacheMap.get(repo)
+            if (cached) {
+                repoData.push({ repo, starRecords: cached.starData, logoUrl: cached.logoUrl })
+            }
+        }
+        if (repoData.length > 0) {
+            setState((prevState) => ({
+                ...prevState,
+                chartData: convertDataToChartData(repoData, state.chartMode, { insertZeroPoint: true, startDate: store.state.startDate })
+            }))
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [store.state.startDate])
 
     const handleCopyLinkBtnClick = async () => {
         try {
@@ -386,7 +405,25 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
                                 </label>
                             </div>
                         </div>
-                        <div className="absolute top-0 right-1 p-2 flex flex-row">
+                        <div className="absolute top-0 right-1 p-2 flex flex-row flex-wrap justify-end items-center">
+                            <div className="flex flex-row justify-center items-center rounded leading-8 text-sm px-3 z-10 text-dark select-none">
+                                <label className="mr-1 whitespace-nowrap">Date from:</label>
+                                <input
+                                    className="border border-gray-300 rounded px-1 text-sm leading-6"
+                                    type="date"
+                                    value={store.state.startDate ?? ""}
+                                    max={new Date().toISOString().slice(0, 10)}
+                                    onChange={(e) => store.actions.setStartDate(e.target.value || null)}
+                                />
+                                {store.state.startDate && (
+                                    <button
+                                        className="ml-1 text-xs text-gray-500 hover:text-dark"
+                                        onClick={() => store.actions.setStartDate(null)}
+                                    >
+                                        Clear
+                                    </button>
+                                )}
+                            </div>
                             <div
                                 className="flex flex-row justify-center items-center rounded leading-8 text-sm px-3 cursor-pointer z-10 text-dark select-none hover:bg-gray-100"
                                 onClick={handleToggleLogScaleBtnClick}
@@ -399,7 +436,7 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
                                 onClick={handleToggleChartBtnClick}
                             >
                                 <input className="mr-2" type="checkbox" checked={state.chartMode === "Timeline"} />
-                                {state.chartMode === "Timeline" ? "Align timeline" : "Align timeline"}
+                                Align timeline
                             </div>
                         </div>
                     </>

--- a/frontend/components/StarChartViewer.tsx
+++ b/frontend/components/StarChartViewer.tsx
@@ -340,6 +340,9 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
     const handleToggleChartBtnClick = React.useCallback(() => {
         const newChartMode = state.chartMode === "Date" ? "Timeline" : "Date"
         store.actions.setChartMode(newChartMode)
+        if (newChartMode === "Timeline") {
+            store.actions.setStartDate(null)
+        }
 
         setState((prevState) => {
             return { ...prevState, chartMode: newChartMode }
@@ -406,24 +409,26 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
                             </div>
                         </div>
                         <div className="absolute top-0 right-1 p-2 flex flex-row flex-wrap justify-end items-center">
-                            <div className="flex flex-row justify-center items-center rounded leading-8 text-sm px-3 z-10 text-dark select-none">
-                                <label className="mr-1 whitespace-nowrap">Date from:</label>
-                                <input
-                                    className="border border-gray-300 rounded px-1 text-sm leading-6"
-                                    type="date"
-                                    value={store.state.startDate ?? ""}
-                                    max={new Date().toISOString().slice(0, 10)}
-                                    onChange={(e) => store.actions.setStartDate(e.target.value || null)}
-                                />
-                                {store.state.startDate && (
-                                    <button
-                                        className="ml-1 text-xs text-gray-500 hover:text-dark"
-                                        onClick={() => store.actions.setStartDate(null)}
-                                    >
-                                        Clear
-                                    </button>
-                                )}
-                            </div>
+                            {state.chartMode !== "Timeline" && (
+                                <div className="flex flex-row justify-center items-center rounded leading-8 text-sm px-3 z-10 text-dark select-none">
+                                    <label className="mr-1 whitespace-nowrap">Date from:</label>
+                                    <input
+                                        className="border border-gray-300 rounded px-1 text-sm leading-6"
+                                        type="date"
+                                        value={store.state.startDate ?? ""}
+                                        max={new Date().toISOString().slice(0, 10)}
+                                        onChange={(e) => store.actions.setStartDate(e.target.value || null)}
+                                    />
+                                    {store.state.startDate && (
+                                        <button
+                                            className="ml-1 text-xs text-gray-500 hover:text-dark"
+                                            onClick={() => store.actions.setStartDate(null)}
+                                        >
+                                            Clear
+                                        </button>
+                                    )}
+                                </div>
+                            )}
                             <div
                                 className="flex flex-row justify-center items-center rounded leading-8 text-sm px-3 cursor-pointer z-10 text-dark select-none hover:bg-gray-100"
                                 onClick={handleToggleLogScaleBtnClick}

--- a/frontend/store/index.tsx
+++ b/frontend/store/index.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 import storage from "../helpers/storage";
 import { ChartMode, LegendPosition } from "@shared/types/chart";
+import { isValidIsoDateString } from "@shared/common/chart";
 import { useRouter } from "next/router";
 
 interface AppState {
@@ -88,8 +89,8 @@ export const AppStateProvider: React.FC<{
                     }
                 } else if (value.startsWith("from=")) {
                     const candidate = value.split("=")[1];
-                    // Accept only YYYY-MM-DD format that parses to a valid date
-                    if (/^\d{4}-\d{2}-\d{2}$/.test(candidate) && !isNaN(Date.parse(candidate))) {
+                    // Accept only YYYY-MM-DD that is a real calendar date (rejects e.g. 2023-02-29).
+                    if (isValidIsoDateString(candidate)) {
                         startDate = candidate;
                     }
                 } else {

--- a/frontend/store/index.tsx
+++ b/frontend/store/index.tsx
@@ -10,6 +10,7 @@ interface AppState {
     chartMode: ChartMode;
     useLogScale: boolean;
     legendPosition: LegendPosition;
+    startDate: string | null;
 }
 
 interface AppStateContextProps {
@@ -18,6 +19,7 @@ interface AppStateContextProps {
     chartMode: ChartMode;
     useLogScale: boolean;
     legendPosition: LegendPosition;
+    startDate: string | null;
     token: string;
     state: AppState;
     actions: {
@@ -29,6 +31,7 @@ interface AppStateContextProps {
         setChartMode(chartMode: ChartMode): void;
         setUseLogScale(useLogScale: boolean): void;
         setLegendPosition(legendPosition: LegendPosition): void;
+        setStartDate(date: string | null): void;
     };
 }
 
@@ -44,6 +47,7 @@ export const AppStateProvider: React.FC<{
         chartMode: "Date",
         useLogScale: false,
         legendPosition: "top-left",
+        startDate: null,
     });
 
     const router = useRouter();
@@ -56,6 +60,7 @@ export const AppStateProvider: React.FC<{
             let chartMode: ChartMode = "Date";
             let useLogScale = false;
             let legendPosition: LegendPosition = "top-left";
+            let startDate: string | null = null;
 
             const validLegendPositions: LegendPosition[] = ["top-left", "bottom-right"];
 
@@ -81,6 +86,12 @@ export const AppStateProvider: React.FC<{
                     if (validLegendPositions.includes(position)) {
                         legendPosition = position;
                     }
+                } else if (value.startsWith("from=")) {
+                    const candidate = value.split("=")[1];
+                    // Accept only YYYY-MM-DD format that parses to a valid date
+                    if (/^\d{4}-\d{2}-\d{2}$/.test(candidate) && !isNaN(Date.parse(candidate))) {
+                        startDate = candidate;
+                    }
                 } else {
                     repos.push(value);
                 }
@@ -94,6 +105,7 @@ export const AppStateProvider: React.FC<{
                 chartMode,
                 useLogScale,
                 legendPosition,
+                startDate,
             }));
         };
 
@@ -142,6 +154,9 @@ export const AppStateProvider: React.FC<{
         setLegendPosition: (legendPosition: LegendPosition) => {
             setState((prev) => ({ ...prev, legendPosition }));
         },
+        setStartDate: (date: string | null) => {
+            setState((prev) => ({ ...prev, startDate: date }));
+        },
     }), []);
 
     const store = useMemo<AppStateContextProps>(() => ({
@@ -150,6 +165,7 @@ export const AppStateProvider: React.FC<{
         chartMode: state.chartMode,
         useLogScale: state.useLogScale,
         legendPosition: state.legendPosition,
+        startDate: state.startDate,
         token: state.token,
         state,
         actions,

--- a/shared/common/chart.tsx
+++ b/shared/common/chart.tsx
@@ -192,10 +192,9 @@ export const convertStarDataToChartData = (reposStarData: RepoStarData[], chartM
     } else {
         const datasets: XYData[] = reposStarData.map((item) => {
             const { repo, starRecords } = item
-            const filtered = startDateStr ? starRecords.filter((r) => normDateStr(r.date) >= startDateStr) : starRecords
 
-            const started = filtered[0]?.date ?? starRecords[0].date
-            const chartData = filtered.map((item) => {
+            const started = starRecords[0].date
+            const chartData = starRecords.map((item) => {
                 return {
                     x: utils.getTimeStampByDate(new Date(item.date)) - utils.getTimeStampByDate(new Date(started)),
                     y: Number(item.count)
@@ -256,11 +255,9 @@ export const convertDataToChartData = (repoData: RepoData[], chartMode: ChartMod
         return { datasets }
     } else {
         const datasets: XYData[] = repoData.map(({ repo, starRecords, logoUrl }) => {
-            const filtered = startDateStr ? starRecords.filter((r) => normDateStr(r.date) >= startDateStr) : starRecords
-            const origin = filtered[0]?.date ?? starRecords[0].date
-            const chartData = filtered.map((item) => {
+            const chartData = starRecords.map((item) => {
                 return {
-                    x: utils.getTimeStampByDate(new Date(item.date)) - utils.getTimeStampByDate(new Date(origin)),
+                    x: utils.getTimeStampByDate(new Date(item.date)) - utils.getTimeStampByDate(new Date(starRecords[0].date)),
                     y: Number(item.count)
                 }
             })

--- a/shared/common/chart.tsx
+++ b/shared/common/chart.tsx
@@ -5,6 +5,17 @@ import utils from "./utils"
 
 export interface ChartDataOptions {
     insertZeroPoint?: boolean
+    startDate?: Date | string | null
+}
+
+// Normalize a star-record date string (yyyy/MM/dd or YYYY-MM-DD) to YYYY-MM-DD for safe string comparison.
+const normDateStr = (date: string): string => date.replace(/\//g, "-")
+
+// Convert an optional startDate (Date object or YYYY-MM-DD string) to a normalized YYYY-MM-DD string.
+const toIsoDateString = (date: Date | string | null | undefined): string | null => {
+    if (!date) return null
+    if (date instanceof Date) return date.toISOString().slice(0, 10)
+    return date
 }
 
 export const DEFAULT_MAX_REQUEST_AMOUNT = 15
@@ -145,10 +156,13 @@ export const getRepoData = async (repos: string[], token = "", maxRequestAmount 
 }
 
 export const convertStarDataToChartData = (reposStarData: RepoStarData[], chartMode: ChartMode, options?: ChartDataOptions): XYChartData => {
+    const startDateStr = toIsoDateString(options?.startDate)
+
     if (chartMode === "Date") {
         const datasets: XYData[] = reposStarData.map((item) => {
             const { repo, starRecords } = item
-            const chartData = starRecords.map((item) => {
+            const filtered = startDateStr ? starRecords.filter((r) => normDateStr(r.date) >= startDateStr) : starRecords
+            const chartData = filtered.map((item) => {
                 return {
                     x: new Date(item.date),
                     y: Number(item.count)
@@ -178,9 +192,10 @@ export const convertStarDataToChartData = (reposStarData: RepoStarData[], chartM
     } else {
         const datasets: XYData[] = reposStarData.map((item) => {
             const { repo, starRecords } = item
+            const filtered = startDateStr ? starRecords.filter((r) => normDateStr(r.date) >= startDateStr) : starRecords
 
-            const started = starRecords[0].date
-            const chartData = starRecords.map((item) => {
+            const started = filtered[0]?.date ?? starRecords[0].date
+            const chartData = filtered.map((item) => {
                 return {
                     x: utils.getTimeStampByDate(new Date(item.date)) - utils.getTimeStampByDate(new Date(started)),
                     y: Number(item.count)
@@ -209,9 +224,12 @@ export const convertStarDataToChartData = (reposStarData: RepoStarData[], chartM
 }
 
 export const convertDataToChartData = (repoData: RepoData[], chartMode: ChartMode, options?: ChartDataOptions): XYChartData => {
+    const startDateStr = toIsoDateString(options?.startDate)
+
     if (chartMode === "Date") {
         const datasets: XYData[] = repoData.map(({ repo, starRecords, logoUrl }) => {
-            const chartData = starRecords.map((item) => {
+            const filtered = startDateStr ? starRecords.filter((r) => normDateStr(r.date) >= startDateStr) : starRecords
+            const chartData = filtered.map((item) => {
                 return {
                     x: new Date(item.date),
                     y: Number(item.count)
@@ -238,9 +256,11 @@ export const convertDataToChartData = (repoData: RepoData[], chartMode: ChartMod
         return { datasets }
     } else {
         const datasets: XYData[] = repoData.map(({ repo, starRecords, logoUrl }) => {
-            const chartData = starRecords.map((item) => {
+            const filtered = startDateStr ? starRecords.filter((r) => normDateStr(r.date) >= startDateStr) : starRecords
+            const origin = filtered[0]?.date ?? starRecords[0].date
+            const chartData = filtered.map((item) => {
                 return {
-                    x: utils.getTimeStampByDate(new Date(item.date)) - utils.getTimeStampByDate(new Date(starRecords[0].date)),
+                    x: utils.getTimeStampByDate(new Date(item.date)) - utils.getTimeStampByDate(new Date(origin)),
                     y: Number(item.count)
                 }
             })

--- a/shared/common/chart.tsx
+++ b/shared/common/chart.tsx
@@ -11,6 +11,20 @@ export interface ChartDataOptions {
 // Normalize a star-record date string (yyyy/MM/dd or YYYY-MM-DD) to YYYY-MM-DD for safe string comparison.
 const normDateStr = (date: string): string => date.replace(/\//g, "-")
 
+// Strictly validate a YYYY-MM-DD string as a real calendar date.
+// Date.parse normalizes invalid days (e.g. "2023-02-29" -> Mar 1), so round-trip the components to reject those.
+export const isValidIsoDateString = (s: string): boolean => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false
+    const [y, m, d] = s.split("-").map(Number)
+    const dt = new Date(Date.UTC(y, m - 1, d))
+    return (
+        !isNaN(dt.getTime()) &&
+        dt.getUTCFullYear() === y &&
+        dt.getUTCMonth() === m - 1 &&
+        dt.getUTCDate() === d
+    )
+}
+
 // Convert an optional startDate (Date object or YYYY-MM-DD string) to a normalized YYYY-MM-DD string.
 const toIsoDateString = (date: Date | string | null | undefined): string | null => {
     if (!date) return null


### PR DESCRIPTION
## Summary

Adds an optional date input that clips the star-history chart to start from a chosen date, addressing [#50](https://github.com/star-history/star-history/issues/50). The chosen date is persisted in the URL hash (`&from=YYYY-MM-DD`) so it survives reload and is shareable, and the backend `/svg` endpoint accepts the same parameter so embedded charts honor it too.

No additional GitHub API calls — filtering happens on already-cached star records in `convertDataToChartData`.

### Changes

- **`shared/common/chart.tsx`** — new `ChartDataOptions.startDate`; filter applied in both Date and Timeline modes. Comparison is on normalized `YYYY-MM-DD` strings (star record dates come as `yyyy/MM/dd` and parse as **local** time, while ISO `YYYY-MM-DD` parses as **UTC** — comparing `Date` objects would produce timezone-dependent off-by-one filtering at the boundary). Timeline-mode origin resets to the first post-filter record.
- **`frontend/store/index.tsx`** — `startDate` state, `setStartDate` action, `from=YYYY-MM-DD` hash parsing with format + parse-validity check.
- **`frontend/components/RepoInputer.tsx`** — includes `&from=YYYY-MM-DD` in the shareable hash.
- **`frontend/components/StarChartViewer.tsx`** — date picker + Clear button in the existing toolbar; dedicated `useEffect` re-derives chart from cache on `startDate` change (no refetch).
- **`backend/main.ts`** — `/svg` accepts `&from=YYYY-MM-DD` (400 on malformed), included in the SVG cache key, passed into `convertDataToChartData`.

URL example: `#owner/repo&type=date&from=2025-08-01&legend=top-left`

## Test plan

- [x] `pnpm run dev` in `frontend/`: load any repo, pick a date in the new input — chart redraws filtered.
- [x] Reload the page — the `from=` value round-trips via the URL hash.
- [x] Click Clear — chart returns to full history; `from=` drops from the hash.
- [x] Set a date later than the repo's last star — no crash, dataset empty for that repo, other repos still render.
- [x] Manually put `&from=garbage` into the hash — ignored, full history rendered.
- [x] Toggle Align timeline while `from=` is set — timelines anchor to each repo's first post-filter star.
- [x] `pnpm dev` in `backend/`: `curl 'localhost:8080/svg?repos=star-history/star-history&from=2025-08-01'` returns an SVG starting at that date; `from=garbage` returns 400.

Fixes #50