### PR TITLE
fix(legend): auto-position legend to avoid overlapping data lines

### DIFF
--- a/backend/main.ts
+++ b/backend/main.ts
@@ -164,9 +164,11 @@ const startServer = async () => {
 
     const useLogScale = logscaleParam !== undefined && logscaleParam !== "false";
 
-    let legendPosition: "top-left" | "bottom-right" = "top-left";
-    if (legendParam === "bottom-right") {
-      legendPosition = "bottom-right";
+    const ALLOWED_LEGEND = ["auto", "top-left", "top-right", "bottom-left", "bottom-right"] as const;
+    type LegendPos = (typeof ALLOWED_LEGEND)[number];
+    let legendPosition: LegendPos = "auto";
+    if ((ALLOWED_LEGEND as readonly string[]).includes(legendParam)) {
+      legendPosition = legendParam as LegendPos;
     }
 
     if (!CHART_SIZES.includes(size)) {

--- a/frontend/components/StarChartViewer.tsx
+++ b/frontend/components/StarChartViewer.tsx
@@ -12,7 +12,7 @@ import { convertDataToChartData, getRepoData } from "@shared/common/chart"
 import toast from "helpers/toast"
 import { ChartMode, RepoData, LegendPosition } from "@shared/types/chart"
 
-const VALID_LEGEND_POSITIONS: LegendPosition[] = ["top-left", "bottom-right"]
+const VALID_LEGEND_POSITIONS: LegendPosition[] = ["auto", "top-left", "top-right", "bottom-left", "bottom-right"]
 import BytebaseBanner from "./SponsorView"
 import utils from "@shared/common/utils"
 import api from "@shared/common/api"
@@ -48,7 +48,7 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
     const [state, setState] = useState<State>({
         chartMode: "Date",
         useLogScale: false,
-        legendPosition: "top-left",
+        legendPosition: "auto",
         repoCacheMap: new Map(),
         chartData: undefined,
         isGeneratingImage: false,
@@ -122,7 +122,7 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
             const useLogScale = hash.includes("logscale") || hash.includes("LogScale");
 
             // Parse legend position from hash
-            let legendPosition: LegendPosition = "top-left";
+            let legendPosition: LegendPosition = "auto";
             const legendRegex = new RegExp(`legend=(${VALID_LEGEND_POSITIONS.join("|")})`);
             const legendMatch = hash.match(legendRegex);
             if (legendMatch) {
@@ -364,26 +364,18 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
                         <div className="absolute top-0 left-1 p-2 flex flex-row">
                             <div className="flex flex-row justify-center items-center rounded leading-8 text-sm px-3 z-10 text-dark select-none">
                                 <span className="mr-2">Legend</span>
-                                <label className="mr-2 cursor-pointer hover:opacity-80 flex items-center">
-                                    <input
-                                        className="mr-1"
-                                        type="radio"
-                                        name="legendPosition"
-                                        checked={state.legendPosition === "top-left"}
-                                        onChange={() => handleLegendPositionChange("top-left")}
-                                    />
-                                    Top left
-                                </label>
-                                <label className="cursor-pointer hover:opacity-80 flex items-center">
-                                    <input
-                                        className="mr-1"
-                                        type="radio"
-                                        name="legendPosition"
-                                        checked={state.legendPosition === "bottom-right"}
-                                        onChange={() => handleLegendPositionChange("bottom-right")}
-                                    />
-                                    Bottom right
-                                </label>
+                                {(["auto", "top-left", "top-right", "bottom-left", "bottom-right"] as LegendPosition[]).map((pos) => (
+                                    <label key={pos} className="mr-2 cursor-pointer hover:opacity-80 flex items-center">
+                                        <input
+                                            className="mr-1"
+                                            type="radio"
+                                            name="legendPosition"
+                                            checked={state.legendPosition === pos}
+                                            onChange={() => handleLegendPositionChange(pos)}
+                                        />
+                                        {pos === "auto" ? "Auto" : pos === "top-left" ? "Top left" : pos === "top-right" ? "Top right" : pos === "bottom-left" ? "Bottom left" : "Bottom right"}
+                                    </label>
+                                ))}
                             </div>
                         </div>
                         <div className="absolute top-0 right-1 p-2 flex flex-row">

--- a/frontend/store/index.tsx
+++ b/frontend/store/index.tsx
@@ -43,7 +43,7 @@ export const AppStateProvider: React.FC<{
         repos: [],
         chartMode: "Date",
         useLogScale: false,
-        legendPosition: "top-left",
+        legendPosition: "auto",
     });
 
     const router = useRouter();
@@ -55,9 +55,9 @@ export const AppStateProvider: React.FC<{
             const repos: string[] = [];
             let chartMode: ChartMode = "Date";
             let useLogScale = false;
-            let legendPosition: LegendPosition = "top-left";
+            let legendPosition: LegendPosition = "auto";
 
-            const validLegendPositions: LegendPosition[] = ["top-left", "bottom-right"];
+            const validLegendPositions: LegendPosition[] = ["auto", "top-left", "top-right", "bottom-left", "bottom-right"];
 
             for (const value of params) {
                 if (value.startsWith("type=")) {

--- a/shared/packages/types.tsx
+++ b/shared/packages/types.tsx
@@ -4,7 +4,7 @@ export type D3Selection = Selection<SVGSVGElement | SVGGElement, unknown, null, 
 
 export type Position = "down_right" | "down_left" | "up_right" | "up_left"
 
-export type LegendPosition = "top-left" | "bottom-right"
+export type LegendPosition = "auto" | "top-left" | "top-right" | "bottom-left" | "bottom-right"
 
 export const colors = [
     "#dd4528", "#28a3dd", "#f3db52", "#ed84b5", "#4ab74e", "#9179c0", "#8e6d5a", "#f19839", "#949494",

--- a/shared/packages/utils/drawLegend.tsx
+++ b/shared/packages/utils/drawLegend.tsx
@@ -1,5 +1,10 @@
+import { AxisScale } from "d3-axis"
 import { D3Selection, LegendPosition } from "../types"
 import uniq from "lodash/uniq"
+
+interface LegendDataset {
+    data: { x: Date | number; y: number }[]
+}
 
 interface DrawLegendConfig {
     items: {
@@ -12,9 +17,68 @@ interface DrawLegendConfig {
     legendPosition: LegendPosition
     chartWidth: number
     chartHeight: number
+    datasets?: LegendDataset[]
+    xScale?: AxisScale<number | Date>
+    yScale?: AxisScale<number>
 }
 
-const drawLegend = (selection: D3Selection, { items, strokeColor, backgroundColor, legendPosition, chartWidth, chartHeight }: DrawLegendConfig) => {
+type Corner = "top-left" | "top-right" | "bottom-left" | "bottom-right"
+
+const CORNER_PREFERENCE: Corner[] = ["top-left", "top-right", "bottom-right", "bottom-left"]
+
+const cornerRect = (corner: Corner, chartWidth: number, chartHeight: number, w: number, h: number) => {
+    // Margins match the original top-left (8/5) and bottom-right (8/15) offsets.
+    switch (corner) {
+        case "top-left":
+            return { x: 8, y: 5 }
+        case "top-right":
+            return { x: chartWidth - w - 8, y: 5 }
+        case "bottom-left":
+            return { x: 8, y: chartHeight - h - 15 }
+        case "bottom-right":
+            return { x: chartWidth - w - 8, y: chartHeight - h - 15 }
+    }
+}
+
+const pickAutoCorner = (
+    chartWidth: number,
+    chartHeight: number,
+    w: number,
+    h: number,
+    datasets: LegendDataset[],
+    xScale: AxisScale<number | Date>,
+    yScale: AxisScale<number>
+): Corner => {
+    const points: { x: number; y: number }[] = []
+    datasets.forEach((ds) => {
+        ds.data.forEach((d) => {
+            const px = xScale(d.x as number | Date) as number
+            const py = yScale(d.y) as number
+            if (Number.isFinite(px) && Number.isFinite(py)) {
+                points.push({ x: px, y: py })
+            }
+        })
+    })
+
+    let bestCorner: Corner = "top-left"
+    let bestScore = Infinity
+    for (const corner of CORNER_PREFERENCE) {
+        const { x, y } = cornerRect(corner, chartWidth, chartHeight, w, h)
+        let score = 0
+        for (const p of points) {
+            if (p.x >= x && p.x <= x + w && p.y >= y && p.y <= y + h) score++
+        }
+        if (score < bestScore) {
+            bestScore = score
+            bestCorner = corner
+            if (score === 0) break // perfect corner — preference order wins ties
+        }
+    }
+    return bestCorner
+}
+
+const drawLegend = (selection: D3Selection, config: DrawLegendConfig) => {
+    const { items, strokeColor, backgroundColor, legendPosition, chartWidth, chartHeight, datasets, xScale, yScale } = config
     const legendXPadding = 7
     const legendYPadding = 6
     const xkcdCharWidth = 7
@@ -38,14 +102,19 @@ const drawLegend = (selection: D3Selection, { items, strokeColor, backgroundColo
     const backgroundWidth = Math.max(bboxWidth + legendXPadding * 2, maxTextLength * xkcdCharWidth + colorBlockWidth + legendXPadding * 2 + 6 + (shouldDrawLogo ? legendXPadding + logoSize : 0))
     const backgroundHeight = items.length * xkcdCharHeight + legendYPadding * 2
 
-    // Calculate position based on legendPosition
-    let legendX = 8
-    let legendY = 5
-
-    if (legendPosition === "bottom-right") {
-        legendX = chartWidth - backgroundWidth - 8
-        legendY = chartHeight - backgroundHeight - 15
+    // Resolve final corner. "auto" scores all four; explicit values pass through.
+    let resolved: Corner
+    if (legendPosition === "auto") {
+        if (datasets && xScale && yScale) {
+            resolved = pickAutoCorner(chartWidth, chartHeight, backgroundWidth, backgroundHeight, datasets, xScale, yScale)
+        } else {
+            resolved = "top-left"
+        }
+    } else {
+        resolved = legendPosition
     }
+
+    const { x: legendX, y: legendY } = cornerRect(resolved, chartWidth, chartHeight, backgroundWidth, backgroundHeight)
 
     items.forEach((item, i) => {
         // draw color dot

--- a/shared/packages/xy-chart.tsx
+++ b/shared/packages/xy-chart.tsx
@@ -79,7 +79,7 @@ const getDefaultOptions = (transparent: boolean): XYChartOptions => {
         fontFamily: "xkcd",
         backgroundColor: transparent ? "transparent" : "white",
         strokeColor: "black",
-        legendPosition: "top-left"
+        legendPosition: "auto"
     }
 }
 
@@ -428,9 +428,12 @@ const XYChart = (
         items: legendItems,
         strokeColor: options.strokeColor,
         backgroundColor: options.backgroundColor,
-        legendPosition: options.legendPosition || "top-left",
+        legendPosition: options.legendPosition || "auto",
         chartWidth,
-        chartHeight
+        chartHeight,
+        datasets: data.datasets,
+        xScale,
+        yScale
     })
 }
 

--- a/shared/types/chart.tsx
+++ b/shared/types/chart.tsx
@@ -1,6 +1,6 @@
 export type ChartMode = "Date" | "Timeline"
 
-export type LegendPosition = "top-left" | "bottom-right"
+export type LegendPosition = "auto" | "top-left" | "top-right" | "bottom-left" | "bottom-right"
 
 export interface StarRecord {
     date: string


### PR DESCRIPTION
## Summary

Fixes #528 — when repos have steep early growth (e.g. `openclaw/openclaw`), the legend in the top-left corner gets overdrawn by rising data lines.

### Changes

- **Auto-placement** (`"auto"`, new default): scores all four corners by counting how many projected data-points fall inside the legend bounding box, picks the emptiest corner. Tie-break order: top-left → top-right → bottom-right → bottom-left, so existing charts with no overlap keep their current look.
- **Two new explicit positions**: `"top-right"` and `"bottom-left"` added alongside the existing `"top-left"` / `"bottom-right"`.
- **Frontend UI**: radio buttons extended from 2 → 5 options (Auto, Top left, Top right, Bottom left, Bottom right). Default is now "Auto".
- **URL hash**: `legend=auto|top-left|top-right|bottom-left|bottom-right` all accepted; invalid values fall back to `"auto"`.
- **Backend `/svg`**: `?legend=` accepts all five values, defaults to `"auto"`.

### Files changed

| File | Change |
|------|--------|
| `shared/packages/types.tsx` | Widen `LegendPosition` union to 5 values |
| `shared/types/chart.tsx` | Same widening for frontend imports |
| `shared/packages/utils/drawLegend.tsx` | `cornerRect()` helper + `pickAutoCorner()` scoring |
| `shared/packages/xy-chart.tsx` | Default to `"auto"`, pass scales to legend |
| `frontend/components/StarChartViewer.tsx` | 5 radio buttons, default "auto" |
| `frontend/store/index.tsx` | Accept all 5 values from URL hash |
| `backend/main.ts` | `?legend=` accepts all 5 values |

### Demo

URL: `/#openclaw/openclaw&type=timeline&logscale&legend=top-right` places the legend in the top-right, away from the steep rising line. With `legend=auto` (default) it picks the corner automatically.

🤖 Generated with [Claude Code](https://claude.ai/code)