### PR TITLE
Add "Date from" filter + legend auto-positioning (merged #527 + #529)

### DIFF
--- a/backend/main.ts
+++ b/backend/main.ts
@@ -5,7 +5,7 @@ import { serve } from "@hono/node-server";
 import { optimize } from 'svgo';
 import { JSDOM } from "jsdom";
 import XYChart from "../shared/packages/xy-chart.js";
-import { convertDataToChartData, getRepoData } from "../shared/common/chart.js";
+import { convertDataToChartData, getRepoData, isValidIsoDateString } from "../shared/common/chart.js";
 import { ChartMode } from "../shared/types/chart.js";
 import logger from "./logger.js";
 import cache, { ogCardCache, svgCache, recordCacheHit, recordCacheMiss, getAllCacheStats } from "./cache.js";
@@ -146,8 +146,19 @@ const startServer = async () => {
     const typeParam = c.req.query("type") ?? "";
     const logscaleParam = c.req.query("logscale");
     const legendParam = c.req.query("legend") ?? "";
+    const fromParam = c.req.query("from") ?? "";
     let type: ChartMode = "Date";
     let size = c.req.query("size") ?? "";
+
+    // #527: Date-from validation
+    let startDate: string | null = null;
+    if (fromParam) {
+      if (isValidIsoDateString(fromParam)) {
+        startDate = fromParam;
+      } else {
+        return c.text("Invalid 'from' parameter: expected a real calendar date in YYYY-MM-DD form", 400);
+      }
+    }
 
     if (typeParam) {
       const lowerType = typeParam.toLowerCase();
@@ -164,17 +175,20 @@ const startServer = async () => {
 
     const useLogScale = logscaleParam !== undefined && logscaleParam !== "false";
 
-    let legendPosition: "top-left" | "bottom-right" = "top-left";
-    if (legendParam === "bottom-right") {
-      legendPosition = "bottom-right";
+    // #529: Extended legend positioning (5 values: auto, top-left, top-right, bottom-left, bottom-right)
+    const ALLOWED_LEGEND = ["auto", "top-left", "top-right", "bottom-left", "bottom-right"] as const;
+    type LegendPos = (typeof ALLOWED_LEGEND)[number];
+    let legendPosition: LegendPos = "auto";
+    if ((ALLOWED_LEGEND as readonly string[]).includes(legendParam)) {
+      legendPosition = legendParam as LegendPos;
     }
 
     if (!CHART_SIZES.includes(size)) {
       size = "laptop";
     }
 
-    // Check rendered SVG cache before any data fetching or rendering.
-    const svgCacheKey = `${repos.join(",")}|${type}|${size}|${theme}|${transparent}|${legendPosition}|${useLogScale}`;
+    // Combined cache key: includes both legendPosition (#529) and startDate (#527)
+    const svgCacheKey = `${repos.join(",")}|${type}|${size}|${theme}|${transparent}|${legendPosition}|${useLogScale}|${startDate ?? ""}`;
     const cachedSvg = svgCache.get(svgCacheKey);
     if (cachedSvg) {
       recordCacheHit("svgChart");
@@ -254,7 +268,7 @@ const startServer = async () => {
           title: "Star History",
           xLabel: type === "Date" ? "Date" : "Timeline",
           yLabel: "GitHub Stars",
-          data: convertDataToChartData(repoData, type),
+          data: convertDataToChartData(repoData, type, { startDate }),
           showDots: false,
           transparent: transparent.toLowerCase() === "true",
           theme: theme === "dark" ? "dark" : "light",

--- a/frontend/components/RepoInputer.tsx
+++ b/frontend/components/RepoInputer.tsx
@@ -91,13 +91,16 @@ export default function RepoInputer({ setChartVisibility }: RepoInputerProps) {
                     hash += "&logscale"
                 }
                 hash += `&legend=${store.state.legendPosition}`
+                if (store.state.startDate && store.state.chartMode !== "Timeline") {
+                    hash += `&from=${store.state.startDate}`
+                }
             }
             // Sync location hash only right here
             window.location.hash = hash
         }
 
         handleWatch()
-    }, [store.state.repos, store.state.chartMode, store.state.useLogScale, store.state.legendPosition, state.repos])
+    }, [store.state.repos, store.state.chartMode, store.state.useLogScale, store.state.legendPosition, store.state.startDate, state.repos])
 
     const handleAddRepoBtnClick = () => {
         if (store.isFetching) {

--- a/frontend/components/StarChartViewer.tsx
+++ b/frontend/components/StarChartViewer.tsx
@@ -12,7 +12,7 @@ import { convertDataToChartData, getRepoData } from "@shared/common/chart"
 import toast from "helpers/toast"
 import { ChartMode, RepoData, LegendPosition } from "@shared/types/chart"
 
-const VALID_LEGEND_POSITIONS: LegendPosition[] = ["top-left", "bottom-right"]
+const VALID_LEGEND_POSITIONS: LegendPosition[] = ["auto", "top-left", "top-right", "bottom-left", "bottom-right"]
 import BytebaseBanner from "./SponsorView"
 import utils from "@shared/common/utils"
 import api from "@shared/common/api"
@@ -48,7 +48,7 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
     const [state, setState] = useState<State>({
         chartMode: "Date",
         useLogScale: false,
-        legendPosition: "top-left",
+        legendPosition: "auto",
         repoCacheMap: new Map(),
         chartData: undefined,
         isGeneratingImage: false,
@@ -108,7 +108,7 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
             } else {
                 setState((prevState) => ({
                     ...prevState,
-                    chartData: convertDataToChartData(repoData, chartMode ?? state.chartMode, { insertZeroPoint: true })
+                    chartData: convertDataToChartData(repoData, chartMode ?? state.chartMode, { insertZeroPoint: true, startDate: store.state.startDate })
                 }))
             }
         },
@@ -122,7 +122,7 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
             const useLogScale = hash.includes("logscale") || hash.includes("LogScale");
 
             // Parse legend position from hash
-            let legendPosition: LegendPosition = "top-left";
+            let legendPosition: LegendPosition = "auto";
             const legendRegex = new RegExp(`legend=(${VALID_LEGEND_POSITIONS.join("|")})`);
             const legendMatch = hash.match(legendRegex);
             if (legendMatch) {
@@ -161,6 +161,25 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [store.repos])
 
+    // Re-compute chart from cache when startDate changes (no network request needed)
+    useEffect(() => {
+        if (store.repos.length === 0) return
+        const repoData: RepoData[] = []
+        for (const repo of store.repos) {
+            const cached = state.repoCacheMap.get(repo)
+            if (cached) {
+                repoData.push({ repo, starRecords: cached.starData, logoUrl: cached.logoUrl })
+            }
+        }
+        if (repoData.length > 0) {
+            setState((prevState) => ({
+                ...prevState,
+                chartData: convertDataToChartData(repoData, state.chartMode, { insertZeroPoint: true, startDate: store.state.startDate })
+            }))
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [store.state.startDate])
+
     const handleCopyLinkBtnClick = async () => {
         try {
             await utils.copyTextToClipboard(window.location.href)
@@ -179,7 +198,6 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
         const svgElement = containerElRef.current?.querySelector("svg")?.cloneNode(true) as SVGSVGElement
         svgElement.querySelectorAll(".chart-tooltip-dot").forEach((d) => d.remove())
         svgElement.querySelectorAll(".browser-only").forEach((d) => d.remove())
-        // convert images from url href to data url href
         for (const i of Array.from(svgElement.querySelectorAll("image"))) {
             const url = i.getAttribute("href")
             if (url) {
@@ -208,7 +226,6 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
         }, 2000)
 
         try {
-            // Get image's width and height from the container, because the svg's width is set to 100%
             const { width: imgWidth, height: imgHeight } = containerElRef.current.getBoundingClientRect()
             const canvas = document.createElement("canvas")
             const scale = Math.floor(window.devicePixelRatio * 2)
@@ -222,7 +239,6 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
             ctx.fillStyle = "white"
             ctx.fillRect(0, 0, canvas.width, canvas.height)
 
-            // draw chart image
             const chartDataURL = utils.convertSVGToDataURL(svgElement)
             const chartImage = new Image()
             chartImage.src = chartDataURL
@@ -321,6 +337,9 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
     const handleToggleChartBtnClick = React.useCallback(() => {
         const newChartMode = state.chartMode === "Date" ? "Timeline" : "Date"
         store.actions.setChartMode(newChartMode)
+        if (newChartMode === "Timeline") {
+            store.actions.setStartDate(null)
+        }
 
         setState((prevState) => {
             return { ...prevState, chartMode: newChartMode }
@@ -364,29 +383,41 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
                         <div className="absolute top-0 left-1 p-2 flex flex-row">
                             <div className="flex flex-row justify-center items-center rounded leading-8 text-sm px-3 z-10 text-dark select-none">
                                 <span className="mr-2">Legend</span>
-                                <label className="mr-2 cursor-pointer hover:opacity-80 flex items-center">
-                                    <input
-                                        className="mr-1"
-                                        type="radio"
-                                        name="legendPosition"
-                                        checked={state.legendPosition === "top-left"}
-                                        onChange={() => handleLegendPositionChange("top-left")}
-                                    />
-                                    Top left
-                                </label>
-                                <label className="cursor-pointer hover:opacity-80 flex items-center">
-                                    <input
-                                        className="mr-1"
-                                        type="radio"
-                                        name="legendPosition"
-                                        checked={state.legendPosition === "bottom-right"}
-                                        onChange={() => handleLegendPositionChange("bottom-right")}
-                                    />
-                                    Bottom right
-                                </label>
+                                {(["auto", "top-left", "top-right", "bottom-left", "bottom-right"] as LegendPosition[]).map((pos) => (
+                                    <label key={pos} className="mr-2 cursor-pointer hover:opacity-80 flex items-center">
+                                        <input
+                                            className="mr-1"
+                                            type="radio"
+                                            name="legendPosition"
+                                            checked={state.legendPosition === pos}
+                                            onChange={() => handleLegendPositionChange(pos)}
+                                        />
+                                        {pos === "auto" ? "Auto" : pos === "top-left" ? "Top left" : pos === "top-right" ? "Top right" : pos === "bottom-left" ? "Bottom left" : "Bottom right"}
+                                    </label>
+                                ))}
                             </div>
                         </div>
-                        <div className="absolute top-0 right-1 p-2 flex flex-row">
+                        <div className="absolute top-0 right-1 p-2 flex flex-row flex-wrap justify-end items-center">
+                            {state.chartMode !== "Timeline" && (
+                                <div className="flex flex-row justify-center items-center rounded leading-8 text-sm px-3 z-10 text-dark select-none">
+                                    <label className="mr-1 whitespace-nowrap">Date from:</label>
+                                    <input
+                                        className="border border-gray-300 rounded px-1 text-sm leading-6"
+                                        type="date"
+                                        value={store.state.startDate ?? ""}
+                                        max={new Date().toISOString().slice(0, 10)}
+                                        onChange={(e) => store.actions.setStartDate(e.target.value || null)}
+                                    />
+                                    {store.state.startDate && (
+                                        <button
+                                            className="ml-1 text-xs text-gray-500 hover:text-dark"
+                                            onClick={() => store.actions.setStartDate(null)}
+                                        >
+                                            Clear
+                                        </button>
+                                    )}
+                                </div>
+                            )}
                             <div
                                 className="flex flex-row justify-center items-center rounded leading-8 text-sm px-3 cursor-pointer z-10 text-dark select-none hover:bg-gray-100"
                                 onClick={handleToggleLogScaleBtnClick}
@@ -399,13 +430,12 @@ function StarChartViewer({ compact = false }: StarChartViewerProps) {
                                 onClick={handleToggleChartBtnClick}
                             >
                                 <input className="mr-2" type="checkbox" checked={state.chartMode === "Timeline"} />
-                                {state.chartMode === "Timeline" ? "Align timeline" : "Align timeline"}
+                                Align timeline
                             </div>
                         </div>
                     </>
                 )}
                 <div id="capture">{state.chartData && state.chartData.datasets.length > 0 && <StarXYChart classname={`w-full h-auto ${compact ? "" : "mt-6"}`} data={state.chartData} chartMode={state.chartMode} useLogScale={state.useLogScale} legendPosition={state.legendPosition} />}</div>
-                {/* ... rest of the JSX here */}
                 {state.showSetTokenDialog && (
                     <TokenSettingDialog
                         onClose={handleSetTokenDialogClose}

--- a/frontend/store/index.tsx
+++ b/frontend/store/index.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 import storage from "../helpers/storage";
 import { ChartMode, LegendPosition } from "@shared/types/chart";
+import { isValidIsoDateString } from "@shared/common/chart";
 import { useRouter } from "next/router";
 
 interface AppState {
@@ -10,6 +11,7 @@ interface AppState {
     chartMode: ChartMode;
     useLogScale: boolean;
     legendPosition: LegendPosition;
+    startDate: string | null;
 }
 
 interface AppStateContextProps {
@@ -18,6 +20,7 @@ interface AppStateContextProps {
     chartMode: ChartMode;
     useLogScale: boolean;
     legendPosition: LegendPosition;
+    startDate: string | null;
     token: string;
     state: AppState;
     actions: {
@@ -29,6 +32,7 @@ interface AppStateContextProps {
         setChartMode(chartMode: ChartMode): void;
         setUseLogScale(useLogScale: boolean): void;
         setLegendPosition(legendPosition: LegendPosition): void;
+        setStartDate(date: string | null): void;
     };
 }
 
@@ -43,7 +47,8 @@ export const AppStateProvider: React.FC<{
         repos: [],
         chartMode: "Date",
         useLogScale: false,
-        legendPosition: "top-left",
+        legendPosition: "auto",
+        startDate: null,
     });
 
     const router = useRouter();
@@ -55,13 +60,13 @@ export const AppStateProvider: React.FC<{
             const repos: string[] = [];
             let chartMode: ChartMode = "Date";
             let useLogScale = false;
-            let legendPosition: LegendPosition = "top-left";
+            let legendPosition: LegendPosition = "auto";
+            let startDate: string | null = null;
 
-            const validLegendPositions: LegendPosition[] = ["top-left", "bottom-right"];
+            const validLegendPositions: LegendPosition[] = ["auto", "top-left", "top-right", "bottom-left", "bottom-right"];
 
             for (const value of params) {
                 if (value.startsWith("type=")) {
-                    // Preferred format: type=timeline or type=date
                     const typeValue = value.split("=")[1].toLowerCase();
                     if (typeValue === "date") {
                         chartMode = "Date";
@@ -69,10 +74,8 @@ export const AppStateProvider: React.FC<{
                         chartMode = "Timeline";
                     }
                 } else if (value === "date" || value === "Date") {
-                    // Backward compatibility: naked date parameter
                     chartMode = "Date";
                 } else if (value === "timeline" || value === "Timeline") {
-                    // Backward compatibility: naked timeline parameter
                     chartMode = "Timeline";
                 } else if (value === "logscale" || value === "LogScale") {
                     useLogScale = true;
@@ -80,6 +83,11 @@ export const AppStateProvider: React.FC<{
                     const position = value.split("=")[1] as LegendPosition;
                     if (validLegendPositions.includes(position)) {
                         legendPosition = position;
+                    }
+                } else if (value.startsWith("from=")) {
+                    const candidate = value.split("=")[1];
+                    if (isValidIsoDateString(candidate)) {
+                        startDate = candidate;
                     }
                 } else {
                     repos.push(value);
@@ -94,13 +102,12 @@ export const AppStateProvider: React.FC<{
                 chartMode,
                 useLogScale,
                 legendPosition,
+                startDate,
             }));
         };
 
-        // Fetch data and set initial state
         fetchData();
 
-        // Listen for hash changes using Next.js router
         const handleHashChange = (url: string) => {
             if (url.includes("#")) {
                 fetchData();
@@ -108,7 +115,6 @@ export const AppStateProvider: React.FC<{
         };
         router.events.on("hashChangeComplete", handleHashChange);
 
-        // Cleanup the event listener
         return () => {
             router.events.off("hashChangeComplete", handleHashChange);
         };
@@ -142,6 +148,9 @@ export const AppStateProvider: React.FC<{
         setLegendPosition: (legendPosition: LegendPosition) => {
             setState((prev) => ({ ...prev, legendPosition }));
         },
+        setStartDate: (date: string | null) => {
+            setState((prev) => ({ ...prev, startDate: date }));
+        },
     }), []);
 
     const store = useMemo<AppStateContextProps>(() => ({
@@ -150,6 +159,7 @@ export const AppStateProvider: React.FC<{
         chartMode: state.chartMode,
         useLogScale: state.useLogScale,
         legendPosition: state.legendPosition,
+        startDate: state.startDate,
         token: state.token,
         state,
         actions,

--- a/shared/common/chart.tsx
+++ b/shared/common/chart.tsx
@@ -5,6 +5,31 @@ import utils from "./utils"
 
 export interface ChartDataOptions {
     insertZeroPoint?: boolean
+    startDate?: Date | string | null
+}
+
+// Normalize a star-record date string (yyyy/MM/dd or YYYY-MM-DD) to YYYY-MM-DD for safe string comparison.
+const normDateStr = (date: string): string => date.replace(/\//g, "-")
+
+// Strictly validate a YYYY-MM-DD string as a real calendar date.
+// Date.parse normalizes invalid days (e.g. "2023-02-29" -> Mar 1), so round-trip the components to reject those.
+export const isValidIsoDateString = (s: string): boolean => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false
+    const [y, m, d] = s.split("-").map(Number)
+    const dt = new Date(Date.UTC(y, m - 1, d))
+    return (
+        !isNaN(dt.getTime()) &&
+        dt.getUTCFullYear() === y &&
+        dt.getUTCMonth() === m - 1 &&
+        dt.getUTCDate() === d
+    )
+}
+
+// Convert an optional startDate (Date object or YYYY-MM-DD string) to a normalized YYYY-MM-DD string.
+const toIsoDateString = (date: Date | string | null | undefined): string | null => {
+    if (!date) return null
+    if (date instanceof Date) return date.toISOString().slice(0, 10)
+    return date
 }
 
 export const DEFAULT_MAX_REQUEST_AMOUNT = 15
@@ -145,10 +170,13 @@ export const getRepoData = async (repos: string[], token = "", maxRequestAmount 
 }
 
 export const convertStarDataToChartData = (reposStarData: RepoStarData[], chartMode: ChartMode, options?: ChartDataOptions): XYChartData => {
+    const startDateStr = toIsoDateString(options?.startDate)
+
     if (chartMode === "Date") {
         const datasets: XYData[] = reposStarData.map((item) => {
             const { repo, starRecords } = item
-            const chartData = starRecords.map((item) => {
+            const filtered = startDateStr ? starRecords.filter((r) => normDateStr(r.date) >= startDateStr) : starRecords
+            const chartData = filtered.map((item) => {
                 return {
                     x: new Date(item.date),
                     y: Number(item.count)
@@ -209,9 +237,12 @@ export const convertStarDataToChartData = (reposStarData: RepoStarData[], chartM
 }
 
 export const convertDataToChartData = (repoData: RepoData[], chartMode: ChartMode, options?: ChartDataOptions): XYChartData => {
+    const startDateStr = toIsoDateString(options?.startDate)
+
     if (chartMode === "Date") {
         const datasets: XYData[] = repoData.map(({ repo, starRecords, logoUrl }) => {
-            const chartData = starRecords.map((item) => {
+            const filtered = startDateStr ? starRecords.filter((r) => normDateStr(r.date) >= startDateStr) : starRecords
+            const chartData = filtered.map((item) => {
                 return {
                     x: new Date(item.date),
                     y: Number(item.count)

--- a/shared/packages/types.tsx
+++ b/shared/packages/types.tsx
@@ -4,7 +4,7 @@ export type D3Selection = Selection<SVGSVGElement | SVGGElement, unknown, null, 
 
 export type Position = "down_right" | "down_left" | "up_right" | "up_left"
 
-export type LegendPosition = "top-left" | "bottom-right"
+export type LegendPosition = "auto" | "top-left" | "top-right" | "bottom-left" | "bottom-right"
 
 export const colors = [
     "#dd4528", "#28a3dd", "#f3db52", "#ed84b5", "#4ab74e", "#9179c0", "#8e6d5a", "#f19839", "#949494",
@@ -16,7 +16,6 @@ export const darkColors = [
     "#00d2d3", "#f78fb3", "#badc58", "#ff7979", "#7ed6df", "#f9ca24", "#b388ff", "#4dd0e1", "#ff80ab", "#9fa8da", "#f5b041",
 ]
 
-// Compact palette used by backend SVG generation
 export const colorsCompact = ["#dd4528", "#28a3dd", "#f3db52", "#ed84b5", "#4ab74e", "#9179c0", "#8e6d5a", "#f19839", "#949494"]
 
 export const darkColorsCompact = ["#ff6b6b", "#48dbfb", "#feca57", "#ff9ff3", "#1dd1a1", "#f368e0", "#ff9f43", "#a4b0be", "#576574"]

--- a/shared/packages/utils/drawLegend.tsx
+++ b/shared/packages/utils/drawLegend.tsx
@@ -1,5 +1,10 @@
+import { AxisScale } from "d3-axis"
 import { D3Selection, LegendPosition } from "../types"
 import uniq from "lodash/uniq"
+
+interface LegendDataset {
+    data: { x: Date | number; y: number }[]
+}
 
 interface DrawLegendConfig {
     items: {
@@ -12,9 +17,68 @@ interface DrawLegendConfig {
     legendPosition: LegendPosition
     chartWidth: number
     chartHeight: number
+    datasets?: LegendDataset[]
+    xScale?: AxisScale<number | Date>
+    yScale?: AxisScale<number>
 }
 
-const drawLegend = (selection: D3Selection, { items, strokeColor, backgroundColor, legendPosition, chartWidth, chartHeight }: DrawLegendConfig) => {
+type Corner = "top-left" | "top-right" | "bottom-left" | "bottom-right"
+
+const CORNER_PREFERENCE: Corner[] = ["top-left", "top-right", "bottom-right", "bottom-left"]
+
+const cornerRect = (corner: Corner, chartWidth: number, chartHeight: number, w: number, h: number) => {
+    // Margins match the original top-left (8/5) and bottom-right (8/15) offsets.
+    switch (corner) {
+        case "top-left":
+            return { x: 8, y: 5 }
+        case "top-right":
+            return { x: chartWidth - w - 8, y: 5 }
+        case "bottom-left":
+            return { x: 8, y: chartHeight - h - 15 }
+        case "bottom-right":
+            return { x: chartWidth - w - 8, y: chartHeight - h - 15 }
+    }
+}
+
+const pickAutoCorner = (
+    chartWidth: number,
+    chartHeight: number,
+    w: number,
+    h: number,
+    datasets: LegendDataset[],
+    xScale: AxisScale<number | Date>,
+    yScale: AxisScale<number>
+): Corner => {
+    const points: { x: number; y: number }[] = []
+    datasets.forEach((ds) => {
+        ds.data.forEach((d) => {
+            const px = xScale(d.x as number | Date) as number
+            const py = yScale(d.y) as number
+            if (Number.isFinite(px) && Number.isFinite(py)) {
+                points.push({ x: px, y: py })
+            }
+        })
+    })
+
+    let bestCorner: Corner = "top-left"
+    let bestScore = Infinity
+    for (const corner of CORNER_PREFERENCE) {
+        const { x, y } = cornerRect(corner, chartWidth, chartHeight, w, h)
+        let score = 0
+        for (const p of points) {
+            if (p.x >= x && p.x <= x + w && p.y >= y && p.y <= y + h) score++
+        }
+        if (score < bestScore) {
+            bestScore = score
+            bestCorner = corner
+            if (score === 0) break // perfect corner — preference order wins ties
+        }
+    }
+    return bestCorner
+}
+
+const drawLegend = (selection: D3Selection, config: DrawLegendConfig) => {
+    const { items, strokeColor, backgroundColor, legendPosition, chartWidth, chartHeight, datasets, xScale, yScale } = config
     const legendXPadding = 7
     const legendYPadding = 6
     const xkcdCharWidth = 7
@@ -38,14 +102,19 @@ const drawLegend = (selection: D3Selection, { items, strokeColor, backgroundColo
     const backgroundWidth = Math.max(bboxWidth + legendXPadding * 2, maxTextLength * xkcdCharWidth + colorBlockWidth + legendXPadding * 2 + 6 + (shouldDrawLogo ? legendXPadding + logoSize : 0))
     const backgroundHeight = items.length * xkcdCharHeight + legendYPadding * 2
 
-    // Calculate position based on legendPosition
-    let legendX = 8
-    let legendY = 5
-
-    if (legendPosition === "bottom-right") {
-        legendX = chartWidth - backgroundWidth - 8
-        legendY = chartHeight - backgroundHeight - 15
+    // Resolve final corner. "auto" scores all four; explicit values pass through.
+    let resolved: Corner
+    if (legendPosition === "auto") {
+        if (datasets && xScale && yScale) {
+            resolved = pickAutoCorner(chartWidth, chartHeight, backgroundWidth, backgroundHeight, datasets, xScale, yScale)
+        } else {
+            resolved = "top-left"
+        }
+    } else {
+        resolved = legendPosition
     }
+
+    const { x: legendX, y: legendY } = cornerRect(resolved, chartWidth, chartHeight, backgroundWidth, backgroundHeight)
 
     items.forEach((item, i) => {
         // draw color dot

--- a/shared/packages/xy-chart.tsx
+++ b/shared/packages/xy-chart.tsx
@@ -79,7 +79,7 @@ const getDefaultOptions = (transparent: boolean): XYChartOptions => {
         fontFamily: "xkcd",
         backgroundColor: transparent ? "transparent" : "white",
         strokeColor: "black",
-        legendPosition: "top-left"
+        legendPosition: "auto"
     }
 }
 
@@ -428,9 +428,12 @@ const XYChart = (
         items: legendItems,
         strokeColor: options.strokeColor,
         backgroundColor: options.backgroundColor,
-        legendPosition: options.legendPosition || "top-left",
+        legendPosition: options.legendPosition || "auto",
         chartWidth,
-        chartHeight
+        chartHeight,
+        datasets: data.datasets,
+        xScale,
+        yScale
     })
 }
 

--- a/shared/types/chart.tsx
+++ b/shared/types/chart.tsx
@@ -1,6 +1,6 @@
 export type ChartMode = "Date" | "Timeline"
 
-export type LegendPosition = "top-left" | "bottom-right"
+export type LegendPosition = "auto" | "top-left" | "top-right" | "bottom-left" | "bottom-right"
 
 export interface StarRecord {
     date: string


### PR DESCRIPTION
Combines both features into one clean PR:

### Date-from filter (#527)
- Optional date input to clip chart from a chosen date
- `from=YYYY-MM-DD` in URL hash + `/svg` API
- No extra API calls — filters cached star records

### Legend auto-positioning (#529)
- Auto-placement (default) scores all 4 corners, picks emptiest
- Supports `auto`, `top-left`, `top-right`, `bottom-left`, `bottom-right`
- Extends frontend radio buttons and `/svg` API

### Conflict resolution
- Unified `backend/main.ts` with both features
- Combined SVG cache key

Fixes #52, Fixes #528

Replaces closed #527, #529, #530