### PR TITLE
fix: use privacy-safe GitHub star history endpoint

### DIFF
--- a/backend/const.ts
+++ b/backend/const.ts
@@ -2,9 +2,8 @@ export const CHART_TYPES = ["Date", "Timeline"];
 
 export const CHART_SIZES = ["mobile", "laptop", "desktop"];
 
-// We can reduce the request amount by change MAX_REQUEST_AMOUNT,
-// the default value is the same as frontend.
-export const MAX_REQUEST_AMOUNT = 16;
+// Limit simultaneous GitHub history requests; all pages are needed for accurate totals.
+export const MAX_CONCURRENT_REQUESTS = 16;
 
 // Maximum number of repos allowed per /svg request.
 export const MAX_REPOS_PER_REQUEST = 20;

--- a/backend/main.ts
+++ b/backend/main.ts
@@ -15,7 +15,7 @@ import {
   getBase64Image,
 } from "./utils.js";
 import { getNextToken, markTokenExhausted, initTokenFromEnv } from "./token.js";
-import { CHART_SIZES, MAX_REQUEST_AMOUNT, MAX_REPOS_PER_REQUEST } from "./const.js";
+import { CHART_SIZES, MAX_CONCURRENT_REQUESTS, MAX_REPOS_PER_REQUEST } from "./const.js";
 import { initOgAssets, renderOgCard } from "./og-card.js";
 import { loadRepos } from "../shared/common/repo-data.js";
 
@@ -208,7 +208,7 @@ const startServer = async () => {
       }
 
       try {
-        const data = await getRepoData(nodataRepos, token, MAX_REQUEST_AMOUNT);
+        const data = await getRepoData(nodataRepos, token, MAX_CONCURRENT_REQUESTS);
 
         // Fetch all logos in parallel (bounded by MAX_REPOS_PER_REQUEST)
         await Promise.all(data.map(async (d) => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
         "build": "pnpm run generate:blog && next build && next-sitemap",
         "start": "pnpm dlx serve out",
         "lint": "next lint",
+        "test:api": "node --import tsx --test ../shared/common/api.test.tsx",
         "prettier": "prettier --write ."
     },
     "dependencies": {

--- a/shared/common/api.test.tsx
+++ b/shared/common/api.test.tsx
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict"
+import { afterEach, test } from "node:test"
+import axios from "axios"
+import api from "./api"
+import utils from "./utils"
+
+const originalAdapter = axios.defaults.adapter
+const week = 1736035200 // January 5, 2025
+const weekSeconds = 7 * 86400
+const date = (seconds: number) => utils.getDateString(seconds * 1000)
+
+afterEach(() => { axios.defaults.adapter = originalAdapter })
+
+function mockHistory(pages: { week: number; total: number; days: number[] }[][], currentCount: number, nextOnly = false) {
+    const requests: { url: URL; headers: any }[] = []
+    axios.defaults.adapter = async (config) => {
+        const url = new URL(config.url!)
+        requests.push({ url, headers: config.headers })
+        let data: unknown = { stargazers_count: currentCount }
+        const headers: Record<string, string> = {}
+        if (url.pathname.endsWith("/stargazers/history")) {
+            const page = Number(url.searchParams.get("page"))
+            assert.equal(url.searchParams.get("per_page"), "30")
+            assert.ok(page >= 1 && page <= pages.length)
+            data = pages[page - 1]
+            if (page < pages.length) {
+                // Deliberately put page before per_page and last before next.
+                const link = (n: number, rel: string) => `<https://api.github.com/repositories/1/stargazers/history?page=${n}&per_page=30>; rel="${rel}"`
+                headers.link = (nextOnly ? "" : link(pages.length, "last") + ", ") + link(page + 1, "next")
+            }
+        } else {
+            assert.equal(url.pathname, "/repos/owner/repo")
+        }
+        return { data, headers, status: 200, statusText: "OK", config }
+    }
+    return requests
+}
+
+test("accumulates daily buckets oldest first and preserves the current count", async () => {
+    const requests = mockHistory([
+        [{ week: week + weekSeconds, total: 3, days: [0, 3, 0, 0, 0, 0, 0] }],
+        [{ week, total: 5, days: [0, 2, 0, 3, 0, 0, 0] }],
+    ], 7)
+    const records = await api.getRepoStarRecords("owner/repo", "test-token", 15)
+    assert.deepEqual(records[0], { date: date(week + 86400), count: 2 })
+    assert.deepEqual(records[1], { date: date(week + 2 * 86400), count: 2 })
+    assert.deepEqual(records[2], { date: date(week + 3 * 86400), count: 5 })
+    assert.deepEqual(records[8], { date: date(week + weekSeconds + 2 * 86400), count: 8 })
+    assert.equal(records[records.length - 1].count, 7)
+    assert.equal(requests.length, 3)
+    assert.equal(requests[0].headers.Accept, "application/vnd.github+json")
+    assert.equal(requests[0].headers["X-GitHub-Api-Version"], "2026-03-10")
+    assert.equal(requests[0].headers.Authorization, "token test-token")
+})
+
+test("fetches every page even when the concurrency limit is smaller than the page count", async () => {
+    const pages = Array.from({ length: 5 }, (_, i) => [{ week: week + (4 - i) * weekSeconds, total: 1, days: [1, 0, 0, 0, 0, 0, 0] }])
+    const requests = mockHistory(pages, 5)
+    const records = await api.getRepoStarRecords("owner/repo", "", 2)
+    assert.deepEqual(requests.slice(0, -1).map(({ url }) => url.searchParams.get("page")), ["1", "2", "3", "4", "5"])
+    assert.equal(records[0].count, 1)
+    assert.equal(records[records.length - 2].count, 5)
+    assert.equal(requests[0].headers.Authorization, "")
+})
+
+test("follows next links when no last link is provided", async () => {
+    const requests = mockHistory([
+        [{ week: week + weekSeconds, total: 1, days: [1, 0, 0, 0, 0, 0, 0] }],
+        [{ week, total: 1, days: [1, 0, 0, 0, 0, 0, 0] }],
+    ], 2, true)
+    const records = await api.getRepoStarRecords("owner/repo", "", 0)
+    assert.equal(requests.length, 3)
+    assert.equal(records[records.length - 2].count, 2)
+})
+
+test("omits future days from the current week", async () => {
+    const today = Math.floor(Date.now() / 86400000) * 86400
+    mockHistory([[{ week: today, total: 1, days: [1, 0, 0, 0, 0, 0, 0] }]], 1)
+    const records = await api.getRepoStarRecords("owner/repo", "", 1)
+    assert.equal(records.length, 2)
+    assert.equal(records[0].date, date(today))
+})
+
+for (const pages of [[[]], [[{ week, total: 0, days: [0, 0, 0, 0, 0, 0, 0] }]]]) {
+    test(`preserves the no-history error for ${pages[0].length ? "zero-filled" : "empty"} history`, async () => {
+        const requests = mockHistory(pages, 0)
+        await assert.rejects(api.getRepoStarRecords("owner/repo", "", 15), { status: 200, data: [] })
+        assert.equal(requests.length, 1)
+    })
+}
+
+test("propagates GitHub failures without falling back to private stargazer identities", async () => {
+    const failure = { response: { status: 403 } }
+    axios.defaults.adapter = async () => { throw failure }
+    await assert.rejects(api.getRepoStarRecords("owner/repo", "", 15), (error) => error === failure)
+})

--- a/shared/common/api.tsx
+++ b/shared/common/api.tsx
@@ -1,19 +1,32 @@
 import axios from "axios"
 import utils from "./utils"
 
-const API_PER_PAGE = 100  // GitHub API max items per request
+const API_PER_PAGE = 30  // GitHub star history API max weeks per request
+const DAY_MS = 24 * 60 * 60 * 1000
 const REQUEST_TIMEOUT_MS = 15000  // 15s timeout for GitHub API calls
 
-namespace api {
-    export async function getRepoStargazers(repo: string, token?: string, page?: number) {
-        let url = `https://api.github.com/repos/${repo}/stargazers?per_page=${API_PER_PAGE}`
+interface StarHistoryWeek {
+    week: number
+    total: number
+    days: number[]
+}
 
-        if (page !== undefined) {
-            url = `${url}&page=${page}`
+function getLinkedPage(link: string, relation: string): number | undefined {
+    for (const part of link.split(",")) {
+        const match = /<([^>]+)>;\s*rel="([^"]+)"/.exec(part)
+        if (match?.[2] === relation) {
+            const page = Number(new URL(match[1]).searchParams.get("page"))
+            if (Number.isInteger(page) && page > 0) return page
         }
-        return axios.get(url, {
+    }
+}
+
+namespace api {
+    export async function getRepoStarHistory(repo: string, token?: string, page = 1) {
+        return axios.get<StarHistoryWeek[]>(`https://api.github.com/repos/${repo}/stargazers/history?per_page=${API_PER_PAGE}&page=${page}`, {
             headers: {
-                Accept: "application/vnd.github.v3.star+json",
+                Accept: "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2026-03-10",
                 Authorization: token ? `token ${token}` : ""
             },
             timeout: REQUEST_TIMEOUT_MS,
@@ -32,85 +45,44 @@ namespace api {
         return data.stargazers_count
     }
 
-    export async function getRepoStarRecords(repo: string, token: string, maxRequestAmount: number) {
-        const patchRes = await getRepoStargazers(repo, token)
+    export async function getRepoStarRecords(repo: string, token: string, maxConcurrentRequests: number) {
+        let response = await getRepoStarHistory(repo, token)
+        const weeks = [...response.data]
+        const concurrency = Number.isFinite(maxConcurrentRequests) ? Math.max(1, Math.floor(maxConcurrentRequests)) : 1
 
-        const headerLink = patchRes.headers["link"] || ""
-
-        let pageCount = 1
-        const regResult = /next.*&page=(\d*).*last/.exec(headerLink)
-
-        if (regResult) {
-            if (regResult[1] && Number.isInteger(Number(regResult[1]))) {
-                pageCount = Number(regResult[1])
-            }
+        // Every page is required: these buckets contain increments, not cumulative totals.
+        // Bound concurrency instead of sampling pages and silently dropping stars.
+        let nextPage = getLinkedPage(response.headers["link"] || "", "next")
+        while (nextPage !== undefined) {
+            if (nextPage > 100) throw new Error("GitHub star history exceeds the API pagination limit")
+            const lastPage = getLinkedPage(response.headers["link"] || "", "last") || nextPage
+            const pages = utils.range(nextPage, Math.min(lastPage, nextPage + concurrency - 1, 100))
+            const responses = await Promise.all(pages.map((page) => getRepoStarHistory(repo, token, page)))
+            responses.forEach(({ data }) => weeks.push(...data))
+            response = responses[responses.length - 1]
+            nextPage = getLinkedPage(response.headers["link"] || "", "next")
         }
 
-        if (pageCount === 1 && patchRes?.data?.length === 0) {
-            throw {
-                status: patchRes.status,
-                data: []
-            }
-        }
-
-        const requestPages: number[] = []
-        if (pageCount < maxRequestAmount) {
-            requestPages.push(...utils.range(1, pageCount))
-        } else {
-            utils.range(1, maxRequestAmount).map((i) => {
-                requestPages.push(Math.round((i * pageCount) / maxRequestAmount) - 1)
-            })
-            if (!requestPages.includes(1)) {
-                requestPages[0] = 1;
-            }
-        }
-
-        const resArray = await Promise.all(
-            requestPages.map((page) => {
-                return getRepoStargazers(repo, token, page)
-            })
-        )
-
-        const starRecordsMap: Map<string, number> = new Map()
-
-        if (requestPages.length < maxRequestAmount) {
-            const starRecordsData: {
-                starred_at: string
-            }[] = []
-            resArray.map((res) => {
-                const { data } = res
-                starRecordsData.push(...data)
-            })
-            for (let i = 0; i < starRecordsData.length; ) {
-                starRecordsMap.set(utils.getDateString(starRecordsData[i].starred_at), i + 1)
-                i += Math.floor(starRecordsData.length / maxRequestAmount) || 1
-            }
-        } else {
-            resArray.map(({ data }, index) => {
-                if (data.length > 0) {
-                    const starRecord = data[0]
-                    // Calculate actual star position based on API page size and position in page
-                    const pageStartPosition = API_PER_PAGE * (requestPages[index] - 1)
-                    starRecordsMap.set(utils.getDateString(starRecord.starred_at), pageStartPosition)
-                }
-            })
-        }
-
-        const starAmount = await getRepoStargazersCount(repo, token)
-        starRecordsMap.set(utils.getDateString(Date.now()), starAmount)
-
-        const starRecords: {
-            date: string
-            count: number
-        }[] = []
-
-        starRecordsMap.forEach((v, k) => {
-            starRecords.push({
-                date: k,
-                count: v
+        const starRecords: { date: string; count: number }[] = []
+        let count = 0
+        const now = Date.now()
+        // Pages and weeks are newest first; days within each week start on Sunday.
+        weeks.reverse().forEach((week) => {
+            week.days.forEach((stars, day) => {
+                const timestamp = week.week * 1000 + day * DAY_MS
+                if (timestamp > now) return
+                count += stars
+                // Do not move the timeline's origin back before the first star.
+                if (count > 0) starRecords.push({ date: utils.getDateString(timestamp), count })
             })
         })
 
+        if (starRecords.length === 0) {
+            throw { status: response.status, data: [] }
+        }
+
+        const starAmount = await getRepoStargazersCount(repo, token)
+        starRecords.push({ date: utils.getDateString(now), count: starAmount })
         return starRecords
     }
 

--- a/shared/common/chart.tsx
+++ b/shared/common/chart.tsx
@@ -7,16 +7,16 @@ export interface ChartDataOptions {
     insertZeroPoint?: boolean
 }
 
-export const DEFAULT_MAX_REQUEST_AMOUNT = 15
+export const DEFAULT_MAX_CONCURRENT_REQUESTS = 15
 
 const STAR_HISTORY_LOGO_URL = "https://avatars.githubusercontent.com/u/124480067"
 
-export const getReposStarData = async (repos: string[], token = "", maxRequestAmount = DEFAULT_MAX_REQUEST_AMOUNT): Promise<RepoStarData[]> => {
+export const getReposStarData = async (repos: string[], token = "", maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS): Promise<RepoStarData[]> => {
     const repoStarDataCacheMap = new Map()
 
     for (const repo of repos) {
         try {
-            const starRecords = await api.getRepoStarRecords(repo, token, maxRequestAmount)
+            const starRecords = await api.getRepoStarRecords(repo, token, maxConcurrentRequests)
             repoStarDataCacheMap.set(repo, starRecords)
         } catch (error: any) {
             let message = ""
@@ -62,7 +62,7 @@ export const getReposStarData = async (repos: string[], token = "", maxRequestAm
     })
 }
 
-export const getRepoData = async (repos: string[], token = "", maxRequestAmount = DEFAULT_MAX_REQUEST_AMOUNT): Promise<RepoData[]> => {
+export const getRepoData = async (repos: string[], token = "", maxConcurrentRequests = DEFAULT_MAX_CONCURRENT_REQUESTS): Promise<RepoData[]> => {
     const repoDataCacheMap: Map<
         string,
         {
@@ -77,7 +77,7 @@ export const getRepoData = async (repos: string[], token = "", maxRequestAmount 
     for (const repo of repos) {
         try {
             const [starRecords, logo] = await Promise.all([
-                api.getRepoStarRecords(repo, token, maxRequestAmount),
+                api.getRepoStarRecords(repo, token, maxConcurrentRequests),
                 api.getRepoLogoUrl(repo, token),
             ])
             repoDataCacheMap.set(repo, { star: starRecords, logo })


### PR DESCRIPTION
Replace stargazer identity requests with GitHub's new `/repos/{owner}/{repo}/stargazers/history` endpoint, using API version `2026-03-10`.

Weekly buckets contain daily increments, so fetch every page with bounded concurrency and accumulate counts oldest first. Preserve the current star-count point, omit future days, and retain the existing no-history and API-error behavior. Rename the request limits to reflect their concurrency role.

Closes #553

Validation:
- All 7 API regression tests pass (`cd frontend && pnpm test:api`), covering pagination, ordering, current counts, empty history, and API errors.
- Focused TypeScript check of the API and tests passes.
- Verified a live history response from GitHub, including weekly buckets and pagination headers.
- Full frontend TypeScript check is blocked by missing generated `gh/data/*.json` and `frontend/helpers/blog.json` files and the resulting implicit-any errors. The same errors reproduce on untouched upstream.
